### PR TITLE
Allow "Terraform destroy" to delete dataset contents.

### DIFF
--- a/02-dataexchange.tf
+++ b/02-dataexchange.tf
@@ -10,6 +10,12 @@ module "thelook-dataset" {
   project_id     = module.land-project.project_id
   id             = var.thelook_dataset
   location       = var.location
+  options        = {
+    default_table_expiration_ms     = null
+    default_partition_expiration_ms = null
+    delete_contents_on_destroy      = var.delete_contents_on_destroy
+    max_time_travel_hours           = null
+  }
 }
 
 # Setting up the transfer of the sample data set "thelook_ecommerce" from the public project "bigquery-public-data" to the Data Clean Room project
@@ -35,6 +41,12 @@ module "dcr-dataset" {
   project_id     = module.land-project.project_id
   id             = var.dcr_dataset
   location       = var.location
+  options        = {
+    default_table_expiration_ms     = null
+    default_partition_expiration_ms = null
+    delete_contents_on_destroy      = var.delete_contents_on_destroy
+    max_time_travel_hours           = null
+  }
 }
 
 # Creating a view with a privacy policy - this makes the dataexchange behave like a Data Clean Room 

--- a/04-publisher.tf
+++ b/04-publisher.tf
@@ -106,10 +106,17 @@ module "publisher-dataset" {
   project_id     = module.prc-project.project_id
   id             = "publisher_dataset"
   location       = var.location
+  options        = {
+    default_table_expiration_ms     = null
+    default_partition_expiration_ms = null
+    delete_contents_on_destroy      = var.delete_contents_on_destroy
+    max_time_travel_hours           = null
+  }
   tables = {
     users = {
       friendly_name       = "users"
       schema = local.publisher_schema_users
+      deletion_protection = var.deletion_protection
     }
   }
 }
@@ -140,6 +147,12 @@ module "dcr-publisher-dataset" {
   project_id     = module.prc-project.project_id
   id             = "dcr_publisher_dataset"
   location       = var.location
+  options        = {
+    default_table_expiration_ms     = null
+    default_partition_expiration_ms = null
+    delete_contents_on_destroy      = var.delete_contents_on_destroy
+    max_time_travel_hours           = null
+  }
 }
 
 resource "null_resource" "dcr-publisher-view" {

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -25,3 +25,12 @@ thelook_dataset = "thelook" # should onlycontain lowercase letters, numbers and 
 data_exchange = "DataCleanRoom"
 dcr_dataset = "dcr_dataset"
 dcr_listing = "dcr_listing"
+
+# Location
+location = "eu"
+
+# If set to true, allow Terraform to delete all the tables in the publisher_dataset when destroying the resource
+delete_contents_on_destroy = true
+
+# Configures deletion_protection for the users table. If unset, module-level deletion_protection setting will be used.
+deletion_protection = false

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,12 @@ variable "deletion_protection" {
   nullable    = false
 }
 
+variable "delete_contents_on_destroy" {
+  description = "If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present."
+  type        = bool
+  default     = false
+}
+
 variable "enable_services" {
   description = "Flag to enable or disable services in the Data Platform."
   type = object({


### PR DESCRIPTION
Expose Terraform `delete_contents_on_destroy` and `deletion_protection` variables to allow deletion of dataset contents/tables on destroy. 

Also expose `location` variable (MULTI_REGIONAL).